### PR TITLE
include effects of spoke tension

### DIFF
--- a/bikewheelcalc/femsolution.py
+++ b/bikewheelcalc/femsolution.py
@@ -10,6 +10,7 @@ N_RIM = 1
 N_HUB = 2
 N_REF = 3
 
+
 class FEMSolution:
     el_rim = 1
     el_spoke = 2
@@ -139,7 +140,7 @@ class FEMSolution:
 
         # internal forces at each node
         self.spokes_t = []  # spoke tension
-        
+
         self.rim_t = []     # rim tension (hoop stress)
         self.rim_v_i = []   # in-plane shear
         self.rim_v_o = []   # out-of-plane shear


### PR DESCRIPTION
Spoke tension is incorporated into the spoke stiffness matrix as a 1st-order effect (tensed-string stiffness). The stiffness matrix is first constructed assuming that the spoke tensions are uniform and equal to the specified pretension. The spoke stresses are calculated, and the updated spoke tensions are used to recalculate the stiffness matrix and solve again for the stabilized solution.