### PR TITLE
Incorporate spoke adjustment into matrix equation

### DIFF
--- a/bikewheelcalc/bicycle_wheel.py
+++ b/bikewheelcalc/bicycle_wheel.py
@@ -241,6 +241,10 @@ class Spoke:
     def calc_tension_change(self, d, a=0.):
         'Calculate change in tension given d=(u,v,w,phi) and a tightening adjustment a'
 
+        # Assume phi=0 if not given
+        if len(d) < 4:
+            d = np.append(d, 0.)
+
         # u_n = u_s + phi(e_3 x b)
         e3 = np.array([0., 0., 1.])
         un = np.array([d[0], d[1], d[2]]) + d[3]*np.cross(e3, self.b)

--- a/bikewheelcalc/bicycle_wheel.py
+++ b/bikewheelcalc/bicycle_wheel.py
@@ -238,6 +238,15 @@ class Spoke:
         else:
             return None
 
+    def calc_tension_change(self, d, a=0.):
+        'Calculate change in tension given d=(u,v,w,phi) and a tightening adjustment a'
+
+        # u_n = u_s + phi(e_3 x b)
+        e3 = np.array([0., 0., 1.])
+        un = np.array([d[0], d[1], d[2]]) + d[3]*np.cross(e3, self.b)
+
+        return self.EA/self.length * (a - self.n.dot(un))
+
     def __init__(self, rim_pt, hub_pt, diameter, young_mod, density=None):
         self.EA = np.pi / 4 * diameter**2 * young_mod
         self.diameter = diameter

--- a/bikewheelcalc/bicycle_wheel.py
+++ b/bikewheelcalc/bicycle_wheel.py
@@ -175,11 +175,6 @@ class Spoke:
         n = self.n                   # spoke vector
         e3 = np.array([0., 0., 1.])  # rim axial vector
 
-        # Spoke nipple offset vector (relative to shear center)
-        # TODO: Correctly calculate v-component of b_s based on rim radius.
-        #       Set to zero for now.
-        b = np.array([self.rim_pt[2], 0., 0.])
-
         K_e = self.EA / self.length
 
         if tension:
@@ -190,10 +185,10 @@ class Spoke:
         k_f = K_e*np.outer(n, n) + K_t*(np.eye(3) - np.outer(n, n))
 
         # Change in force applied by spoke due to rim rotation, phi
-        dFdphi = k_f.dot(np.cross(e3, b).reshape((3, 1)))
+        dFdphi = k_f.dot(np.cross(e3, self.b).reshape((3, 1)))
 
         # Change in torque applied by spoke due to rim rotation
-        dTdphi = np.cross(b, e3).dot(k_f).dot(np.cross(b, e3))
+        dTdphi = np.cross(self.b, e3).dot(k_f).dot(np.cross(self.b, e3))
 
         k = np.zeros((4, 4))
 
@@ -210,18 +205,13 @@ class Spoke:
         n = self.n
         e3 = np.array([0., 0., 1.])
 
-        # Spoke nipple offset vector (relative to shear center)
-        # TODO: Correctly calculate v-component of b_s based on rim radius.
-        #       Set to zero for now.
-        b = np.array([self.rim_pt[2], 0., 0.])
-
         k_f = (1./self.length) * (np.eye(3) - np.outer(n, n))
 
         # Change in force applied by spoke due to rim rotation, phi
-        dFdphi = k_f.dot(np.cross(e3, b).reshape((3, 1)))
+        dFdphi = k_f.dot(np.cross(e3, self.b).reshape((3, 1)))
 
         # Change in torque applied by spoke due to rim rotation
-        dTdphi = np.cross(b, e3).dot(k_f).dot(np.cross(b, e3))
+        dTdphi = np.cross(self.b, e3).dot(k_f).dot(np.cross(self.b, e3))
 
         k = np.zeros((4, 4))
 
@@ -267,6 +257,11 @@ class Spoke:
 
         # Spoke axial unit vector
         self.n = np.array([du, dv, dw]) / self.length
+
+        # Spoke nipple offset vector (relative to shear center)
+        # TODO: Correctly calculate v-component of b_s based on rim radius.
+        #       Set to zero for now.
+        self.b = np.array([rim_pt[2], 0., 0.])
 
         # Approximate projected angles
         self.alpha = np.arctan(du / dv)

--- a/bikewheelcalc/mode_matrix.py
+++ b/bikewheelcalc/mode_matrix.py
@@ -212,6 +212,21 @@ class ModeMatrix:
 
         return F_ext.flatten()
 
+    def A_adj(self):
+        'Calculate spoke adjustment matrix.'
+
+        e3 = np.array([0., 0., 1.])  # rim axial vector
+
+        A = np.zeros((4 + self.n_modes*8, len(self.wheel.spokes)))
+
+        for i, s in enumerate(self.wheel.spokes):
+            b = np.array([s.rim_pt[2], 0., 0.])
+            A[:, i] = self.B_theta(s.rim_pt[1]).T\
+                .dot(np.append(s.n, e3.dot(np.cross(s.b, s.n))))
+
+        return A
+
+
     def get_ix_uncoupled(self, dim='lateral'):
         'Get indices for either lateral/torsional or radial/tangential modes.'
 

--- a/bikewheelcalc/mode_matrix.py
+++ b/bikewheelcalc/mode_matrix.py
@@ -138,7 +138,7 @@ class ModeMatrix:
 
         return len(w.spokes)/(2*pi*R) * K_rim_geom
 
-    def K_spk_geom(self, smeared_spokes=True):
+    def K_spk_geom(self, smeared_spokes=False):
         'Tension-dependent portion of K_spk, such that K_spk = K_spk_matl + T_avg*K_spk_geom'
 
         K_spk = np.zeros((4 + self.n_modes*8, 4 + self.n_modes*8))
@@ -179,7 +179,7 @@ class ModeMatrix:
 
         return K_rim
 
-    def K_spk(self, smeared_spokes=True, tension=True):
+    def K_spk(self, smeared_spokes=False, tension=True):
         'Calculate spoke mode stiffness matrix.'
 
         K_spk = np.zeros((4 + self.n_modes*8, 4 + self.n_modes*8))

--- a/bikewheelcalc/mode_matrix.py
+++ b/bikewheelcalc/mode_matrix.py
@@ -268,6 +268,17 @@ class ModeMatrix:
         'Calculate rim cross-section rotation at the location(s) specified by theta.'
         return self.B_theta(theta, 3).dot(dm)
 
+    def spoke_tension_change(self, dm, a=None):
+        'Return a vector of tension changes for each spoke.'
+
+        if a is None:
+            a = np.zeros(self.n_spokes)
+
+        dT = [s.calc_tension_change(self.B_theta(s.rim_pt[1]).dot(dm), adj)
+              for s, adj in zip(self.wheel.spokes, a)]
+
+        return np.array(dT)
+
     def __init__(self, wheel, N=10):
 
         self.wheel = wheel

--- a/bikewheelcalc/mode_matrix.py
+++ b/bikewheelcalc/mode_matrix.py
@@ -221,7 +221,7 @@ class ModeMatrix:
 
         for i, s in enumerate(self.wheel.spokes):
             b = np.array([s.rim_pt[2], 0., 0.])
-            A[:, i] = self.B_theta(s.rim_pt[1]).T\
+            A[:, i] = s.EA/s.length * self.B_theta(s.rim_pt[1]).T\
                 .dot(np.append(s.n, e3.dot(np.cross(s.b, s.n))))
 
         return A

--- a/tests/test_bicycle_wheel.py
+++ b/tests/test_bicycle_wheel.py
@@ -128,16 +128,16 @@ def test_calc_tension_change(std_ncross):
     s = w.spokes[5]  # random spoke number
 
     # Tighten spoke with fixed ends
-    dT = s.calc_tension_change([0., 0., 0., 0.], a=0.001)
+    dT = s.calc_tension_change([0., 0., 0., 1.], a=0.001)
     assert np.allclose(dT, s.EA/s.length*0.001)
 
     # Check tension change for 1% extension
-    dT = s.calc_tension_change(np.append(-0.01*s.length*s.n, 0.))
+    dT = s.calc_tension_change(-0.01*s.length*s.n)
     assert np.allclose(dT, 0.01*s.EA)
 
     # No tension change for displacement perpendicular to spoke vector
     u = 0.001*np.cross([0., 0., 1.], s.n)
-    dT = s.calc_tension_change(np.append(u, 0.))
+    dT = s.calc_tension_change(u)
     assert np.allclose(dT, 0.)
 
 

--- a/tests/test_bicycle_wheel.py
+++ b/tests/test_bicycle_wheel.py
@@ -38,7 +38,7 @@ def test_hub_asymm_offset():
 
 
 # -----------------------------------------------------------------------------
-# Spoke stiffness tests
+# Spoke tests
 # -----------------------------------------------------------------------------
 
 @pytest.mark.parametrize('n_cross', [0, 1, 2, 3])
@@ -121,9 +121,28 @@ def test_calc_kbar_offset_zero_eig(std_ncross, offset):
 
     assert np.allclose(np.min(w), 0.)
 
+def test_calc_tension_change(std_ncross):
+    'Check basic properties of Spoke.calc_tension_change()'
+
+    w = std_ncross(3)
+    s = w.spokes[5]  # random spoke number
+
+    # Tighten spoke with fixed ends
+    dT = s.calc_tension_change([0., 0., 0., 0.], a=0.001)
+    assert np.allclose(dT, s.EA/s.length*0.001)
+
+    # Check tension change for 1% extension
+    dT = s.calc_tension_change(np.append(-0.01*s.length*s.n, 0.))
+    assert np.allclose(dT, 0.01*s.EA)
+
+    # No tension change for displacement perpendicular to spoke vector
+    u = 0.001*np.cross([0., 0., 1.], s.n)
+    dT = s.calc_tension_change(np.append(u, 0.))
+    assert np.allclose(dT, 0.)
+
 
 # -----------------------------------------------------------------------------
-# Tension tests
+# Wheel tension tests
 # -----------------------------------------------------------------------------
 
 @pytest.mark.parametrize('n_cross', [0, 1, 2, 3])

--- a/tests/test_mode_matrix.py
+++ b/tests/test_mode_matrix.py
@@ -5,7 +5,7 @@ from bikewheelcalc import *
 
 
 # -----------------------------------------------------------------------------
-# Stiffness matrixtests
+# Stiffness matrix tests
 # -----------------------------------------------------------------------------
 
 def test_K_matl_geom(std_ncross):
@@ -100,6 +100,11 @@ def test_K_lat(std_ncross):
 
     assert np.allclose(K_lat_mode, K_lat_mm)
 
+
+# -----------------------------------------------------------------------------
+# Spoke adjustment tests
+# -----------------------------------------------------------------------------
+
 def test_A_adj(std_ncross):
     'Check properties of the spoke adjustment matrix'
 
@@ -113,3 +118,24 @@ def test_A_adj(std_ncross):
     assert np.allclose(mm.A_adj()[:, 5],
                        mm.F_ext(theta=s.rim_pt[1],
                                 f=s.EA/s.length * np.append(s.n, 0.)))
+
+def test_spoke_tension(std_ncross):
+    'Check that Spoke.calc_tension_change() and ModeMatrix.spoke_tension_change give same result.'
+
+    w = std_ncross(3)
+    mm = ModeMatrix(w, N=10)
+
+    # No deformation, only adjustment
+    dm = np.zeros(4 + 8*10)
+    a = np.zeros(len(w.spokes))
+    a[5] = 0.001
+
+    dT = mm.spoke_tension_change(dm, a)
+    dT_s = w.spokes[5].calc_tension_change([0., 0., 0., 0.], a[5])
+
+    # Check correct result for single spoke
+    assert np.allclose(dT[5], dT_s)
+
+    # Check all others are zero
+    assert np.allclose(dT[:5], 0.)
+    assert np.allclose(dT[6:], 0.)

--- a/tests/test_mode_matrix.py
+++ b/tests/test_mode_matrix.py
@@ -99,3 +99,17 @@ def test_K_lat(std_ncross):
     K_lat_mm = 1. / mm.B_theta(0.)[:, ix_uc].dot(d)[0]
 
     assert np.allclose(K_lat_mode, K_lat_mm)
+
+def test_A_adj(std_ncross):
+    'Check properties of the spoke adjustment matrix'
+
+    w = std_ncross(3)
+    mm = ModeMatrix(w, N=10)
+
+    A = mm.A_adj()
+
+    # Spoke adjustment has the same effect as a force applied along the spoke vector
+    i = 5  # Chose an arbitrary spoke
+    assert np.allclose(mm.A_adj()[:, i],
+                       mm.F_ext(theta=w.spokes[i].rim_pt[1], 
+                                f=np.append(w.spokes[i].n, 0.)))

--- a/tests/test_mode_matrix.py
+++ b/tests/test_mode_matrix.py
@@ -109,7 +109,7 @@ def test_A_adj(std_ncross):
     A = mm.A_adj()
 
     # Spoke adjustment has the same effect as a force applied along the spoke vector
-    i = 5  # Chose an arbitrary spoke
-    assert np.allclose(mm.A_adj()[:, i],
-                       mm.F_ext(theta=w.spokes[i].rim_pt[1], 
-                                f=np.append(w.spokes[i].n, 0.)))
+    s = w.spokes[5]  # Chose an arbitrary spoke
+    assert np.allclose(mm.A_adj()[:, 5],
+                       mm.F_ext(theta=s.rim_pt[1],
+                                f=s.EA/s.length * np.append(s.n, 0.)))


### PR DESCRIPTION
The mode matrix equation is now:

`(K_rim + K_spk)*d = F_ext + A_adj*a`

where `a` is a vector of spoke length adjustments, in units of meters. A positive adjustment means shortening the spoke (and nominally tightening the spoke).

The spoke adjustment matrix can be calculated using the method `ModeMatrix.A_adj()`.