### PR TITLE
Allow for radial component of spoke offset vector

### DIFF
--- a/bikewheelcalc/bicycle_wheel.py
+++ b/bikewheelcalc/bicycle_wheel.py
@@ -297,7 +297,7 @@ class BicycleWheel:
             theta_hub = theta_rim + 2*np.pi/n_spokes*n_cross*s_dir
 
             du = self.hub.width_nds - offset
-            dv = (self.rim.radius -
+            dv = (self.rim.radius - offset_rad -
                   self.hub.diameter_nds/2*np.cos(theta_hub - theta_rim))
             dw = self.hub.diameter_nds/2*np.sin(theta_hub - theta_rim)
 
@@ -321,7 +321,7 @@ class BicycleWheel:
             theta_hub = theta_rim + 2*np.pi/n_spokes*n_cross*s_dir
 
             du = -self.hub.width_ds + offset
-            dv = (self.rim.radius -
+            dv = (self.rim.radius - offset_rad -
                   self.hub.diameter_ds/2*np.cos(theta_hub - theta_rim))
             dw = self.hub.diameter_ds/2*np.sin(theta_hub - theta_rim)
 

--- a/bikewheelcalc/bicycle_wheel.py
+++ b/bikewheelcalc/bicycle_wheel.py
@@ -438,12 +438,13 @@ class BicycleWheel:
             I_spokes = 0.
             warn('Some spoke densities are not specified.')
         else:
-            rim_pt = np.array([0., -self.rim.radius + s.b[1]], 0.)
-            hub_pt = rim_pt + s.n*s.length
-            mid_pt = 0.5*(rim_pt + hub_pt)
-            mr2_spk = np.array([s.calc_mass()*(mid_pt[0]**2 + mid_pt[1]**2)
-                                for s in self.spokes])
-            I_spokes = np.sum(I_spk) + np.sum(mr2_spk)
+            I_spokes = 0.
+            for i, s in enumerate(self.spokes):
+                rim_pt = np.array([0., -self.rim.radius + s.b[1], 0.])
+                hub_pt = rim_pt + s.n*s.length
+                mid_pt = 0.5*(rim_pt + hub_pt)
+                mr2_spk = s.calc_mass()*(mid_pt[0]**2 + mid_pt[1]**2)
+                I_spokes = I_spokes + I_spk[i] + mr2_spk
 
         return I_rim + I_spokes
 

--- a/bikewheelcalc/mode_matrix.py
+++ b/bikewheelcalc/mode_matrix.py
@@ -162,7 +162,7 @@ class ModeMatrix:
             T_d = np.abs(s_0.n[0]*s_1.n[1]) + np.abs(s_1.n[0]*s_0.n[1])
 
             for s in self.wheel.spokes:
-                B = self.B_theta(s.rim_pt[1])
+                B = self.B_theta(s.theta)
                 K_spk = K_spk + 2*np.abs(s.n[0])/T_d * B.T.dot(s.calc_k_geom().dot(B))
 
         return K_spk
@@ -198,7 +198,7 @@ class ModeMatrix:
         else:  # Fully-discrete spokes
 
             for s in self.wheel.spokes:
-                B = self.B_theta(s.rim_pt[1])
+                B = self.B_theta(s.theta)
                 K_spk = K_spk + B.T.dot(s.calc_k(tension=tension).dot(B))
 
         return K_spk
@@ -219,8 +219,7 @@ class ModeMatrix:
         A = np.zeros((4 + self.n_modes*8, len(self.wheel.spokes)))
 
         for i, s in enumerate(self.wheel.spokes):
-            b = np.array([s.rim_pt[2], 0., 0.])
-            A[:, i] = s.EA/s.length * self.B_theta(s.rim_pt[1]).T\
+            A[:, i] = s.EA/s.length * self.B_theta(s.theta).T\
                 .dot(np.append(s.n, e3.dot(np.cross(s.b, s.n))))
 
         return A
@@ -273,7 +272,7 @@ class ModeMatrix:
         if a is None:
             a = np.zeros(self.n_spokes)
 
-        dT = [s.calc_tension_change(self.B_theta(s.rim_pt[1]).dot(dm), adj)
+        dT = [s.calc_tension_change(self.B_theta(s.theta).dot(dm), adj)
               for s, adj in zip(self.wheel.spokes, a)]
 
         return np.array(dT)

--- a/bikewheelcalc/theory.py
+++ b/bikewheelcalc/theory.py
@@ -207,7 +207,7 @@ def calc_tor_stiff(wheel, theta=0., N=20, smeared_spokes=True, tension=True, buc
 def calc_Pn_lat(wheel):
     'Lateral Pippard number (ratio of length scale to spoke spacing).'
 
-    k_sp = calc_continuum_stiff(wheel)
+    k_sp = wheel.calc_kbar(wheel)
     k_uu = k_sp[0, 0]
 
     n_spokes = len(wheel.spokes)
@@ -224,7 +224,7 @@ def calc_Pn_lat(wheel):
 def calc_Pn_rad(wheel):
     'Radial Pippard number (ratio of length scale to spoke spacing).'
 
-    k_sp = calc_continuum_stiff(wheel)
+    k_sp = wheel.calc_kbar(wheel)
     k_vv = k_sp[1, 1]
 
     n_spokes = len(wheel.spokes)
@@ -239,7 +239,7 @@ def calc_Pn_rad(wheel):
 def calc_lambda_lat(wheel):
     'Calculate lambda = k_uu*R^4/EI_lat'
 
-    k_sp = calc_continuum_stiff(wheel)
+    k_sp = wheel.calc_kbar(wheel)
     k_uu = k_sp[0, 0]
 
     return k_uu*wheel.rim.radius**4 / (wheel.rim.young_mod * wheel.rim.I_lat)
@@ -248,7 +248,7 @@ def calc_lambda_lat(wheel):
 def calc_lambda_rad(wheel):
     'Calculate lambda = k_vv*R^4/EI_rad'
 
-    k_sp = calc_continuum_stiff(wheel)
+    k_sp = wheel.calc_kbar(wheel)
     k_vv = k_sp[1, 1]
 
     return k_vv*wheel.rim.radius**4 / (wheel.rim.young_mod * wheel.rim.I_rad)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ def std_ncross():
 
     def _build_wheel(n_cross=0):
         w = BicycleWheel()
-        w.hub = Hub(diameter=0.050, width=0.05)
+        w.hub = Hub(diameter=0.050, width=0.050)
         w.rim = Rim(radius=0.3, area=100e-6,
                     I_lat=200./69e9, I_rad=100./69e9, J_tor=25./26e9, I_warp=0.0,
                     young_mod=69e9, shear_mod=26e9)
@@ -29,7 +29,7 @@ def std_no_spokes():
 
     def _build_wheel():
         w = BicycleWheel()
-        w.hub = Hub(diameter=0.050, width=0.05)
+        w.hub = Hub(diameter=0.050, width=0.050)
         w.rim = Rim(radius=0.3, area=100e-6,
                     I_lat=200./69e9, I_rad=100./69e9, J_tor=25./26e9, I_warp=0.0,
                     young_mod=69e9, shear_mod=26e9)

--- a/tests/test_bicycle_wheel.py
+++ b/tests/test_bicycle_wheel.py
@@ -230,18 +230,20 @@ def test_lace_cross_nds(std_no_spokes):
 
     w.lace_cross_nds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9, offset=0.01)
 
-    # Check theta positions
-    assert np.allclose([s.rim_pt[1] for s in w.spokes], np.arange(0., 2*np.pi, 2*np.pi/18.))
+    # Check rim theta positions
+    assert np.allclose([s.theta for s in w.spokes], np.arange(0., 2*np.pi, 2*np.pi/18.))
 
-    # Check leading spokes
-    assert np.allclose([s.hub_pt[1] for s in w.spokes[::2]],
-                       np.arange(0., 2.*np.pi, 2.*np.pi/9.)
-                       + 2*np.pi/18.*3.)
+    # Check spoke vectors for leading spokes
+    n_ll = np.array([0.025 - 0.01,
+                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.025*np.sin(2*np.pi/18*3)])
+    n_lt = np.array([0.025 - 0.01,
+                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     -0.025*np.sin(2*np.pi/18*3)])
 
-    # Check trailing spokes
-    assert np.allclose([s.hub_pt[1] for s in w.spokes[1::2]],
-                       np.arange(2.*np.pi/18, 2.*np.pi, 2.*np.pi/9.)
-                       - 2.*np.pi/18.*3.)
+    assert np.all([np.allclose(s.n*s.length, n_ll) for s in w.spokes[::2]])
+    assert np.all([np.allclose(s.n*s.length, n_lt) for s in w.spokes[1::4]])
+
 
 def test_lace_cross_ds(std_no_spokes):
 
@@ -249,18 +251,19 @@ def test_lace_cross_ds(std_no_spokes):
 
     w.lace_cross_ds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9, offset=0.01)
 
-    # Check theta positions
-    assert np.allclose([s.rim_pt[1] for s in w.spokes], np.arange(2*np.pi/36., 2*np.pi, 2*np.pi/18.))
+    # Check rim theta positions
+    assert np.allclose([s.theta for s in w.spokes], np.arange(2*np.pi/36., 2*np.pi, 2*np.pi/18.))
 
-    # Check leading spokes
-    assert np.allclose([s.hub_pt[1] for s in w.spokes[::2]],
-                       np.arange(2*np.pi/36., 2.*np.pi, 2.*np.pi/9.)
-                       + 2*np.pi/18.*3.)
+    # Check spoke vectors for leading spokes
+    n_rl = np.array([-0.025 + 0.01,
+                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.025*np.sin(2*np.pi/18*3)])
+    n_rt = np.array([-0.025 + 0.01,
+                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     -0.025*np.sin(2*np.pi/18*3)])
 
-    # Check trailing spokes
-    assert np.allclose([s.hub_pt[1] for s in w.spokes[1::2]],
-                       np.arange(2.*np.pi*(1./36. + 1./18.), 2.*np.pi, 2.*np.pi/9.)
-                       - 2.*np.pi/18.*3.)
+    assert np.all([np.allclose(s.n*s.length, n_rl) for s in w.spokes[::2]])
+    assert np.all([np.allclose(s.n*s.length, n_rt) for s in w.spokes[1::4]])
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_bicycle_wheel.py
+++ b/tests/test_bicycle_wheel.py
@@ -228,17 +228,18 @@ def test_lace_cross_nds(std_no_spokes):
 
     w = std_no_spokes()
 
-    w.lace_cross_nds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9, offset=0.01)
+    w.lace_cross_nds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9,
+                     offset=0.01, offset_rad=0.01)
 
     # Check rim theta positions
     assert np.allclose([s.theta for s in w.spokes], np.arange(0., 2*np.pi, 2*np.pi/18.))
 
     # Check spoke vectors for leading spokes
     n_ll = np.array([0.025 - 0.01,
-                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.3 - 0.025*np.cos(2*np.pi/18*3) - 0.01,
                      0.025*np.sin(2*np.pi/18*3)])
     n_lt = np.array([0.025 - 0.01,
-                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.3 - 0.025*np.cos(2*np.pi/18*3) - 0.01,
                      -0.025*np.sin(2*np.pi/18*3)])
 
     assert np.all([np.allclose(s.n*s.length, n_ll) for s in w.spokes[::2]])
@@ -249,17 +250,18 @@ def test_lace_cross_ds(std_no_spokes):
 
     w = std_no_spokes()
 
-    w.lace_cross_ds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9, offset=0.01)
+    w.lace_cross_ds(n_spokes=18, n_cross=3, diameter=2.0e-3, young_mod=210e9,
+                    offset=0.01, offset_rad=0.01)
 
     # Check rim theta positions
     assert np.allclose([s.theta for s in w.spokes], np.arange(2*np.pi/36., 2*np.pi, 2*np.pi/18.))
 
     # Check spoke vectors for leading spokes
     n_rl = np.array([-0.025 + 0.01,
-                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.3 - 0.025*np.cos(2*np.pi/18*3) - 0.01,
                      0.025*np.sin(2*np.pi/18*3)])
     n_rt = np.array([-0.025 + 0.01,
-                     0.3 - 0.025*np.cos(2*np.pi/18*3),
+                     0.3 - 0.025*np.cos(2*np.pi/18*3) - 0.01,
                      -0.025*np.sin(2*np.pi/18*3)])
 
     assert np.all([np.allclose(s.n*s.length, n_rl) for s in w.spokes[::2]])

--- a/tests/test_mode_matrix.py
+++ b/tests/test_mode_matrix.py
@@ -116,7 +116,7 @@ def test_A_adj(std_ncross):
     # Spoke adjustment has the same effect as a force applied along the spoke vector
     s = w.spokes[5]  # Chose an arbitrary spoke
     assert np.allclose(mm.A_adj()[:, 5],
-                       mm.F_ext(theta=s.rim_pt[1],
+                       mm.F_ext(theta=s.theta,
                                 f=s.EA/s.length * np.append(s.n, 0.)))
 
 def test_spoke_tension(std_ncross):
@@ -149,7 +149,7 @@ def test_uniform_tension(std_ncross):
     mm = ModeMatrix(w, N=24)
     K = mm.K_rim() + mm.K_spk()
 
-    theta_s = [s.rim_pt[1] for s in w.spokes]
+    theta_s = [s.theta for s in w.spokes]
 
     # Tighten all spokes by one millimeter
     a = 0.001*np.ones(len(w.spokes))

--- a/tests/test_theory.py
+++ b/tests/test_theory.py
@@ -148,7 +148,7 @@ def test_Krad_rotsymm(std_ncross):
     w.rim.sec_params['y_0'] = 0.
     w.apply_tension(1.)
 
-    Krad = [calc_rad_stiff(w, theta=s.rim_pt[1], N=36, tension=True,
+    Krad = [calc_rad_stiff(w, theta=s.theta, N=36, tension=True,
                            smeared_spokes=False, coupling=False, r0=True)
             for s in w.spokes[:5]]
 


### PR DESCRIPTION
Previously, only lateral spoke nipple offset was allowed because the Spoke class only knew the coordinates of its endpoints in cylindrical coordinates, but not the rim radius. This pull request addresses #39.

Now, a spoke knows its angular position on the rim, nipple offset vector, axial vector (rim-to-hub), length, diameter, Young's modulus, and density. The spoke lacing methods (defined on BicycleWheel) are now responsible for computing the spoke vector and length.